### PR TITLE
Add a RestartSec to the service unit file to space out restarts.

### DIFF
--- a/src/nix/flake.nix
+++ b/src/nix/flake.nix
@@ -73,6 +73,7 @@
                     serviceConfig = {
                       ExecStart = "${packages."${system}".default}/bin/${dropkickInput.binName} ${dropkickInput.runArgs}";
                       Restart = "on-failure";
+                      RestartSec="2s";
 
                       # sandboxing and other general security:
                       # (see systemd.exec(5) and `systemd-analyze security dropshot-server.service`)


### PR DESCRIPTION
i ran into an issue that resulted in my service failing to come online, which could have been resolved by giving the system a little more time to settle after boot. i noticed the restart attempts for my service were immediate, and so i was hitting the limit fairly quickly, at which point automatic restarts were no longer attempted. giving my service `RestartSec=2s` resolved my particular issue, and it seemed like a worthwhile addition for the general case.

my service was trying to find its database by DNS, which seemed like a good idea at the time.
