### PR TITLE
Breakout `allow-login` build flag into `allow-ssh` and `allow-aws-ssm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "dropkick"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dropkick"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -15,7 +15,11 @@ use std::io::{Read, Seek, SeekFrom, Write};
 pub(crate) struct Args {
     /// Allow SSH login (via SSH keys fetched by cloud-init)
     #[clap(long)]
-    pub(crate) allow_login: bool,
+    pub(crate) allow_ssh: bool,
+
+    /// Allow AWS Systems Manager (SSM)
+    #[clap(long)]
+    pub(crate) allow_aws_ssm: bool,
 
     /// Environment for the dropshot service (see EnvironmentFile in systemd.exec(5))
     #[clap(long)]


### PR DESCRIPTION
For the Online Signing Service I don't want to enable SSH, but I do want AWS SSM, which is a little similar in terms of how the system will be configured, so instead of having a `allow-login` build flag, I made `allow-ssh` and `allow-aws-ssm`, and updated the flake.nix accordingly (I think..).

I've tested this by building and deploying to my OSS Sandbox env, seems to work as expected.