### PR TITLE
Allow all build commands to use `output_path`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dropkick"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/src/oxide.rs
+++ b/src/oxide.rs
@@ -26,7 +26,6 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tempfile::NamedTempFile;
 
 impl Args {
     pub(crate) async fn create_oxide_image(self, deploy: bool) -> Result<String> {
@@ -37,8 +36,7 @@ impl Args {
 
         let hostname = self.hostname.clone();
 
-        let (mut file, temp_path) = NamedTempFile::new()?.into_parts();
-        let metadata = self.create_iso(&mut file)?;
+        let (output_path, metadata) = self.create_iso()?;
         let mut image_name = format!(
             "{name:.len$}-{store_hash}",
             name = metadata.package.name,
@@ -71,7 +69,7 @@ impl Args {
         let mut disk_name = format!("{}-disk", &image_name);
         disk_name.truncate(63);
 
-        let disk_size = get_disk_size(&temp_path.to_path_buf())?;
+        let disk_size = get_disk_size(&output_path.to_path_buf())?;
 
         context
             .client()?
@@ -97,7 +95,7 @@ impl Args {
             .send()
             .await?;
 
-        let mut file = File::open(&temp_path)?;
+        let mut file = File::open(&output_path)?;
         let mut offset = 0;
         let file_size = file.metadata()?.len();
 


### PR DESCRIPTION
This brings the `output_path` parameter and functionality from the `build` command to other build commands, such as `create-ec2-image` and `create-oxide-image`, which enables me to make use of [GitHub Artifact Attestation](https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/) for the builds I'm doing.

In addition to moving `output_path` to `build::Args`, I moved the code that handles creation of the temp and persistent files it into the `build::create_iso`, which seemed more appropriate than leaving it a level up for each of the CLI commands to implement.

Also, I bumped the version number because this is a breaking change.