### PR TITLE
exclude example paths from Dependabot alerts.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "examples/**"
+      - "cdk/example/**"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "examples/**"


### PR DESCRIPTION
There are a number of Dependabot alerts for the examples in this repo. This should silence those.