### PR TITLE
Fix missing string termination.

### DIFF
--- a/src/nix/flake.nix
+++ b/src/nix/flake.nix
@@ -113,7 +113,7 @@
                 plugins = ["github.com/silinternational/certmagic-storage-dynamodb/v3@v3.1.1"];
                 # If you get a hash mismatch, or to update the plugins, replace this with an empty
                 # string, and do a build: nix will show you the correct hash.
-                hash = "sha256-OOTnvZ75LhV++wBCoPSWv9fW7Mdn+h0wlc5Ufw17P+U=;
+                hash = "sha256-OOTnvZ75LhV++wBCoPSWv9fW7Mdn+h0wlc5Ufw17P+U=";
               };
 
               email = "lets-encrypt@oxidecomputer.com";


### PR DESCRIPTION
Apologies, I did see this in local testing, but I thought it was due to something else, I thought I had tested https://github.com/oxidecomputer/dropkick/pull/52 in isolation, but apparently I didn't do that correctly.